### PR TITLE
FIX utf8 email handling

### DIFF
--- a/ext/greenmat/autolink.c
+++ b/ext/greenmat/autolink.c
@@ -223,7 +223,7 @@ sd_autolink__email(
 		return 0;
 
 	for (link_end = 0; link_end < size; ++link_end) {
-		uint8_t c = data[link_end];
+		char c = data[link_end];
 
 		if (isalnum(c))
 			continue;

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -143,6 +143,12 @@ HTML
     assert_equal exp, rd
   end
 
+  def test_auto_linked_email_utf8_issue
+    rd = render_with({ autolink: true }, "r@example.comあ")
+    exp = %{<p><a href="mailto:r@example.com">r@example.com</a>あ</p>\n}
+    assert_equal exp, rd
+  end
+
   def test_memory_leak_when_parsing_char_links
     @markdown.render(<<-leaks)
 2. Identify the wild-type cluster and determine all clusters


### PR DESCRIPTION
Fix email include utf8 handling.

```
test@example.comあ
=> invalid byte sequence in UTF-8
```
